### PR TITLE
Update CreateHandler to not parse ConflictException message. Update p…

### DIFF
--- a/aws-lookoutvision-project/aws-lookoutvision-project.json
+++ b/aws-lookoutvision-project/aws-lookoutvision-project.json
@@ -34,7 +34,7 @@
     "/properties/ProjectName"
   ],
   "primaryIdentifier": [
-    "/properties/Arn"
+    "/properties/ProjectName"
   ],
   "handlers": {
     "create": {

--- a/aws-lookoutvision-project/docs/README.md
+++ b/aws-lookoutvision-project/docs/README.md
@@ -47,7 +47,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 ### Ref
 
-When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the Arn.
+When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the ProjectName.
 
 ### Fn::GetAtt
 

--- a/aws-lookoutvision-project/src/main/java/software/amazon/lookoutvision/project/CreateHandler.java
+++ b/aws-lookoutvision-project/src/main/java/software/amazon/lookoutvision/project/CreateHandler.java
@@ -39,15 +39,11 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 Translator.translateToCreateRequest(model),
                 ClientBuilder.getClient()::createProject);
         } catch (final ConflictException e) {
-            if (e.getMessage().contains(String.format("Project %s already exists", model.getProjectName()))) {
-                final ResourceAlreadyExistsException resourceAlreadyExistsException =
-                    new ResourceAlreadyExistsException(ResourceModel.TYPE_NAME, model.getArn(), e);
+            final ResourceAlreadyExistsException resourceAlreadyExistsException =
+                new ResourceAlreadyExistsException(ResourceModel.TYPE_NAME, model.getProjectName(), e);
 
-                logger.log(resourceAlreadyExistsException.getMessage());
-                throw resourceAlreadyExistsException;
-            }
-
-            throw e;
+            logger.log(resourceAlreadyExistsException.getMessage());
+            throw resourceAlreadyExistsException;
         }
         final String createMessage = String.format("%s successfully created.", ResourceModel.TYPE_NAME);
         logger.log(createMessage);

--- a/aws-lookoutvision-project/src/main/java/software/amazon/lookoutvision/project/ReadHandler.java
+++ b/aws-lookoutvision-project/src/main/java/software/amazon/lookoutvision/project/ReadHandler.java
@@ -7,8 +7,6 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Objects;
-
 public class ReadHandler extends BaseHandler<CallbackContext> {
 
     private AmazonWebServicesClientProxy proxy;
@@ -54,7 +52,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
 
         final software.amazon.cloudformation.exceptions.ResourceNotFoundException rpdkException =
             new software.amazon.cloudformation.exceptions.ResourceNotFoundException(ResourceModel.TYPE_NAME,
-                Objects.toString(nullSafeModel.getPrimaryIdentifier()));
+                nullSafeModel.getProjectName());
 
         logger.log(rpdkException.getMessage());
         throw rpdkException;

--- a/aws-lookoutvision-project/src/test/java/software/amazon/lookoutvision/project/CreateHandlerTest.java
+++ b/aws-lookoutvision-project/src/test/java/software/amazon/lookoutvision/project/CreateHandlerTest.java
@@ -87,9 +87,7 @@ public class CreateHandlerTest {
     public void handleRequest_FailureAlreadyExists() {
         final String projectName = "projectName";
 
-        final ConflictException conflictException = ConflictException.builder()
-            .message("Project " + projectName + " already exists.")
-            .build();
+        final ConflictException conflictException = ConflictException.builder().build();
 
         doThrow(conflictException)
             .when(proxy)


### PR DESCRIPTION
### Description

* Update CreateHandler to not parse ConflictException message. 
* Update primaryIdentifier to ProjectName so that ReadHandler can easily identify project existence
  * primaryIdentifier must be a createOnly or readOnly property. 
  * Project Arns can still be accessed via `GetAtt`. Ref will return the projectName, which is the primary identifier for the project


12/12 contract tests passed
unit tests passed

```
handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                                   [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                                   [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                      [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                   [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                   [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                           [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                           [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                         [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                         [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                         [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                      [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                     [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                   [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                   [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                   [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                  [100%]
```