### PR TITLE
Update log4j to 2.15.0

### DIFF
--- a/aws-lookoutvision-project/docs/README.md
+++ b/aws-lookoutvision-project/docs/README.md
@@ -58,4 +58,3 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### Arn
 
 Returns the <code>Arn</code> value.
-

--- a/aws-lookoutvision-project/docs/README.md
+++ b/aws-lookoutvision-project/docs/README.md
@@ -58,3 +58,4 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### Arn
 
 Returns the <code>Arn</code> value.
+

--- a/aws-lookoutvision-project/pom.xml
+++ b/aws-lookoutvision-project/pom.xml
@@ -42,19 +42,19 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update log4j dep version to 2.15.0 to fix jndi vulnerability problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
