### PR TITLE
Replace build bot with github actions, fix log4j dep version to 2.15.0

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,43 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Set up cloudformation-cli-java-plugin
+        run: pip install cloudformation-cli-java-plugin
+      - name: install and run pre-commit
+        uses: pre-commit/action@v2.0.0
+        with:
+          extra_args: --all-files
+      - name: Run maven verify for all resources
+        run: |
+          for directory in $GITHUB_WORKSPACE/aws-*; do
+            cd "$directory"
+            mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B clean verify
+          done
+      - name: Failure diff
+        if: ${{ failure() }}
+        run: git diff

--- a/aws-lookoutvision-project/.gitignore
+++ b/aws-lookoutvision-project/.gitignore
@@ -21,3 +21,7 @@ rpdk.log*
 
 # contains credentials
 sam-tests/
+
+# our logs
+rpdk.log
+rpdk.log*

--- a/aws-lookoutvision-project/pom.xml
+++ b/aws-lookoutvision-project/pom.xml
@@ -42,19 +42,19 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Replace build bot with github actions
* Update log4j dep version to 2.15.0 to fix jndi vulnerability problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
