### PR TITLE
Update regex to prevent unicode characters

### DIFF
--- a/aws-lookoutvision-project/aws-lookoutvision-project.json
+++ b/aws-lookoutvision-project/aws-lookoutvision-project.json
@@ -10,9 +10,7 @@
     "ProjectName": {
       "description": "The name of the Amazon Lookout for Vision project",
       "type": "string",
-      "minLength": 1,
-      "maxLength": 255,
-      "pattern": "[a-zA-Z0-9][a-zA-Z0-9_\\-]*"
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_\\-]{0,254}$"
     }
   },
   "properties": {

--- a/aws-lookoutvision-project/docs/README.md
+++ b/aws-lookoutvision-project/docs/README.md
@@ -35,11 +35,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
-
-_Maximum_: <code>255</code>
-
-_Pattern_: <code>[a-zA-Z0-9][a-zA-Z0-9_\-]*</code>
+_Pattern_: <code>^[a-zA-Z0-9][a-zA-Z0-9_\-]{0,254}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- JSON schema validates the pattern against the string but since the start/end characters aren't in the regex strings like `úa` are considered valid but the service will reject them.
- Remove `minLength` and `maxLength` and use the pattern instead.  Removes warnings related to using both. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
